### PR TITLE
Make babel error in gulp task `custom-js` end `run` task and prevent local Primo server from starting/running

### DIFF
--- a/primo-explore-devenv/gulp/tasks/02-custom-js.js
+++ b/primo-explore-devenv/gulp/tasks/02-custom-js.js
@@ -28,7 +28,7 @@ gulp.task('custom-js', gulp.series('select-view', 'custom-html-templates',(cb) =
         buildByBrowserify().on('end', cb);
     }
     else {
-        buildByConcatination().on('end', cb);
+        buildByConcatination(cb).on('end', cb);
     }
 }));
 
@@ -54,7 +54,7 @@ const getBabelConfig = () => {
     });
 }
 
-function buildByConcatination() {
+function buildByConcatination(cb) {
     return gulp.src([buildParams.customModulePath(),buildParams.mainPath(),buildParams.customNpmJsPath(),buildParams.customNpmDistPath(),'!'+buildParams.customPath(),'!'+buildParams.customNpmJsModulePath(),'!'+buildParams.customNpmJsCustomPath()],{allowEmpty:true})
         .pipe(concat(buildParams.customFile))
         .pipe(babel(getBabelConfig()))
@@ -68,7 +68,7 @@ function buildByConcatination() {
             else {
                 gutil.log(err);
             }
-            this.emit("end");
+            cb(err);
         })
         .pipe(wrap('(function(){\n"use strict";\n<%= contents %>\n})();'))
         .pipe(gulp.dest(buildParams.viewJsDir()));

--- a/primo-explore-devenv/gulp/tasks/08-servers.js
+++ b/primo-explore-devenv/gulp/tasks/08-servers.js
@@ -123,4 +123,4 @@ gulp.task('connect:primo_explore', gulp.series('select-view', function(cb) {
 }));
 
 
-gulp.task('run', gulp.series('select-view', 'connect:primo_explore','reinstall-primo-node-modules','setup_watchers','custom-js','custom-scss','custom-css')); //watch
+gulp.task('run', gulp.series('select-view','custom-js','custom-scss','custom-css','connect:primo_explore','reinstall-primo-node-modules','setup_watchers')); //watch

--- a/scripts/set-up-primo-explore-devenv.sh
+++ b/scripts/set-up-primo-explore-devenv.sh
@@ -56,6 +56,13 @@ sed -i '' 's@    "prompt": "1.0.0",@    "node-sass": "9.0.0",\
     "prompt": "1.0.0",@g' ./package.json
 sed -i '' "s@let sass = require('gulp-sass');@let sass = require('gulp-sass')(require('node-sass'));@g" ./gulp/tasks/03-scss.js
 
+# Babel error when running gulp `custom-js` task should end `run` task and prevent
+# local Primo server from starting/continuing to run.
+sed -i '' "s@buildByConcatination().on('end', cb);@buildByConcatination(cb).on('end', cb);@g" ./gulp/tasks/02-custom-js.js
+sed -i '' "s@function buildByConcatination() {@function buildByConcatination(cb) {@g" ./gulp/tasks/02-custom-js.js
+sed -i '' 's@this.emit("end");@cb(err);@g' ./gulp/tasks/02-custom-js.js
+sed -i '' "s@gulp.task('run', gulp.series('select-view', 'connect:primo_explore','reinstall-primo-node-modules','setup_watchers','custom-js','custom-scss','custom-css')); //watch@gulp.task('run', gulp.series('select-view','custom-js','custom-scss','custom-css','connect:primo_explore','reinstall-primo-node-modules','setup_watchers')); //watch@g" ./gulp/tasks//08-servers.js
+
 # ExLibris .gitignore has bugs in it: https://github.com/NYULibraries/primo-customization/blob/4bd6850cd4a603c31f5c0ef6b6d4e080bc52a28a/primo-explore-devenv/.gitignore#L1-L2
 # ...should be "primo-explore/custom/*" and "primo-explore/custom/*".
 # Also, we need to remove the rule for custom/ as we actually do want to check in


### PR DESCRIPTION
The gulp `run` task from upstream ExLibris `primo-explore-devenv` project will not terminate the `gulp.series` when a babel error occurs in `custom-js` task, and will not shut down the local Primo server which has already been started.
This PR reorders the `gulp.series` of the `run` task such that a babel error in `custom-js` task will stop `gulp.series`, hence preventing the local Primo server from starting/continuing to run.

The necessary changes to _primo-explore-devenv/_ were made by the updated _scripts/set-up-primo-explore-devenv.sh_.