### PR TITLE
Fix small errors in dev and prod NYU view homepage_en.html files

### DIFF
--- a/custom/01NYU_INST-NYU/html/homepage/homepage_en.html
+++ b/custom/01NYU_INST-NYU/html/homepage/homepage_en.html
@@ -15,7 +15,7 @@
                     catalog.</p>
                 <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank"
                             class="md-primoExplore-theme">Report harmful language via the online form</a>, or
-                        through the “Provide Feedback” link in the submenu of every page in the catalog.</b></p>
+                        through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
             </md-card-content>
         </md-card>
 

--- a/custom/01NYU_INST-NYU_DEV/html/homepage/homepage_en.html
+++ b/custom/01NYU_INST-NYU_DEV/html/homepage/homepage_en.html
@@ -15,7 +15,7 @@
                     catalog.</p>
                 <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank"
                             class="md-primoExplore-theme">Report harmful language via the online form</a>, or
-                        through the “Provide Feedback” link in the submenu of every page in the catalog.</b></p>
+                        through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
             </md-card-content>
         </md-card>
 


### PR DESCRIPTION
* Remove carriage returns
* Remove `nyu-lib-changing-the-subject"=""` faux attribute (possible browser-generated source code artifact)
* Fix double-quotes wrapping "Provide Feedback" text

For details on #2 and #3, see [comment in monday.com ticket "Update Landing page Look/Feel"](https://nyu-lib.monday.com/boards/765008773/pulses/4845887231/posts/2362842872).