### PR TITLE
01NYU_INST-NYU{_DEV}/colors.json: change "secondary" from "#57068c" to "#42056a" 

### DIFF
--- a/custom/01NYU_INST-NYU/colors.json
+++ b/custom/01NYU_INST-NYU/colors.json
@@ -1,10 +1,10 @@
 {
   "primary": "#57068c",
-  "secondary" : "#57068c",
+  "secondary" : "#42056a",
   "backgroundColor" : "white",
   "links": "#05568a",
   "warning": "#c50f3c",
   "positive": "#799a05",
   "negative": "#0aa3fc",
-  "notice": "#e08303"
+  "notice": "#b84d00"
 }

--- a/custom/01NYU_INST-NYU_DEV/colors.json
+++ b/custom/01NYU_INST-NYU_DEV/colors.json
@@ -1,10 +1,11 @@
 {
   "primary": "#57068c",
-  "secondary" : "#57068c",
+  "secondary" : "#42056a",
   "backgroundColor" : "white",
   "links": "#05568a",
   "warning": "#c50f3c",
   "positive": "#799a05",
   "negative": "#0aa3fc",
-  "notice": "#e08303"
+  "notice": "#b84d00"
 }
+


### PR DESCRIPTION
Had changed to "#57068c" because of this instruction: [Reimplement Color Scheme](https://nyu-lib.monday.com/boards/765008773/pulses/4885670816) ...but that was just pertaining to a couple of discrete elements, not to a category of colors in the theme.  Those elements will retain their "#57068c" values from custom.css, which will have ordering precedence over the app-colors.css which will be created using colors.json.

Per https://libtechnyu.slack.com/archives/C05NJFWN4LX/p1692719996506949, we are going to use two CSS files in CDN: _app-colors.css_, which will be generated from this _colors.json_ file, and custom.css, which will contain non-color-related styles and also overrides of the _app-colors.css_ styles, if necessary.