### PR TITLE
Add `ipc: host` to e2e docker compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,6 @@ services:
       - primo-customization-net
   e2e:
     <<: *x-build-e2e
-    command: tail -f /dev/null
     depends_on:
       - primo-explore-devenv
     environment:


### PR DESCRIPTION
From [CI configurations > Docker](https://playwright.dev/docs/ci#docker):
    
> Using --ipc=host is also recommended when using Chromium. Without it Chromium can run out of memory and crash.
