### PR TITLE
custom/00_common/js/01-config.js: create `window.nyulibraries` and attach `cdnUrl` to it

### DIFF
--- a/custom/00_common/js/01-config.js
+++ b/custom/00_common/js/01-config.js
@@ -8,6 +8,19 @@ const cdnUrl = getCdnUrl( vid );
 
 console.log( `[DEBUG] cdnUrl = ${ cdnUrl }` );
 
+// All the code in our customization package is run inside an IIFE (Immediately
+// Invoked Function Expression), which means any variables defined here are not
+// accessible to the CDN JS code.  The only way for the CDN JS code to know the
+// CDN URL without duplicating `getCdnUrl()` there is to attach it to an object
+// it has access to, or to inject it in a <script> or DOM element on the page.
+// We choose to attach it to the global `window` object since we are already
+// allowing the Third Iron code to attach the `browzine` object to `window` for
+// LibKey functionality, and it seems safe enough using the `nyulibraries`
+// namespace.
+window.nyulibraries = {
+    cdnUrl,
+};
+
 // This is necessary to allow the `templateURL` method to fetch cross-domain
 // from the CDN.
 app.config( function ( $sceDelegateProvider ) {


### PR DESCRIPTION
Pass `cdnUrl` to CDN JS code via `window.nyulibraries.cdnUrl`.  We don't currently use the CDN url in CDN JS code, but it is likely we will find it handy in the future as we have already made several POCs that require it, and we don't want to duplicate `getCdnUrl()`.
Likewise, the `window.nyulibraries` is a safe, name-spaced global area we can use to pass information from the customization package to CDN JS code.