### PR TITLE
custom/00_common/js/03-inject.js: set up transition from custom.{css,js} -> external.{css,js} in CDN

### DIFF
--- a/custom/00_common/js/03-inject.js
+++ b/custom/00_common/js/03-inject.js
@@ -11,13 +11,31 @@ function injectCDNResourceTags() {
 }
 
 function injectScriptTagForCDNCustomJS() {
-    const script = document.createElement( 'script' );
-    script.setAttribute( 'src', `${ cdnUrl }/js/custom.js` );
-    document.body.appendChild( script );
+    // We have decided to rename CDN custom.{css,js} files to external.{css,js}.
+    // We may not be able to deploy the package and CDN code simultaneously, so
+    // we are setting up a transition phase where we inject script tags for
+    // both custom.js and external.js.  After the CDN has been updated with
+    // new filenames, we will delete the custom.js <script> tag.s
+    const scriptCustom = document.createElement( 'script' );
+    scriptCustom.setAttribute( 'src', `${ cdnUrl }/js/custom.js` );
+    document.body.appendChild( scriptCustom )
+
+    const scriptExternal = document.createElement( 'script' );
+    scriptExternal.setAttribute( 'src', `${ cdnUrl }/js/external.js` );
+    document.body.appendChild( scriptExternal );
 }
 
 function injectLinkTagsForCDNCustomCSS() {
-    [ 'app-colors.css', 'custom.css' ].forEach( file => {
+    [
+        'app-colors.css',
+        // We have decided to rename CDN custom.{css,js} files to external.{css,js}.
+        // We may not be able to deploy the package and CDN code simultaneously, so
+        // we are setting up a transition phase where we inject link tags for
+        // both custom.css and external.css.  After the CDN has been updated with
+        // new filenames, we will delete the custom.css <link> tag.
+        'custom.css',
+        'external.css',
+    ].forEach( file => {
         const link = document.createElement( 'link' );
         link.type = 'text/css';
         link.rel = 'stylesheet';


### PR DESCRIPTION
Inject <script> and <link> tags for both CDN custom.{css,js} and external.{css,js} in anticipation of renaming those files.  Until then, we need the package to be able to still load from custom.{css,js}.