### PR TITLE
Enable playwright CLI options in run tests.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ x-build-unit: &x-build-unit-tests
 
 x-environment: &x-environment
   CI: ${CI}
+  PLAYWRIGHT_COMMAND_LINE_OPTIONS: ${PLAYWRIGHT_COMMAND_LINE_OPTIONS}
   VIEW: ${VIEW}
 
 x-build-primo-customization: &x-build-primo-customization

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -103,6 +103,23 @@ VIEW=01NYU_INST-NYU_DEV docker compose up e2e-update-golden-files
 
 ---
 
+[Playwright options](https://playwright.dev/docs/test-cli) can be passed in
+using the `PLAYWRIGHT_COMMAND_LINE_OPTIONS` environment variable.
+
+Example: override the `workers` setting in _playwright.config.js_:
+
+```shell
+# Tests http://localhost:8003/discovery/search?vid=01NYU_INST:NYU_DEV using 6 workers
+PLAYWRIGHT_COMMAND_LINE_OPTIONS='--workers=6' VIEW=01NYU_INST-NYU_DEV docker compose up e2e
+```
+
+Note that not all command line options will work properly inside a container.
+For example, the `--debug` option for running tests with
+[Playwright Inspector](https://playwright.dev/docs/debug#playwright-inspector) will not work without X11 forwarding or something
+similar already set up.
+
+---
+
 ## CDN test fixture
 
 The CDN test fixture _./fixtures/cdn/_ serves as the default CDN path for the

--- a/test/e2e/scripts/run-tests.sh
+++ b/test/e2e/scripts/run-tests.sh
@@ -10,6 +10,11 @@ if [ -z "$VIEW" ]; then
     exit 1
 fi
 
+if [ "$#" -gt 0 ]
+then
+    PLAYWRIGHT_COMMAND_LINE_OPTIONS="$*"
+fi
+
 TEST_VIEW_DIR=$ROOT/tests
 ACTUAL_DIR=$TEST_VIEW_DIR/actual/$VIEW
 DIFFS_DIR=$TEST_VIEW_DIR/diffs/$VIEW
@@ -29,4 +34,4 @@ rm -rf "${ACTUAL_DIR:?}"/*
 rm -rf "${DIFFS_DIR:?}"/*
 
 # Run tests
-yarn playwright test "$@"
+yarn playwright test "$PLAYWRIGHT_COMMAND_LINE_OPTIONS"


### PR DESCRIPTION
* Allow Playwright command line option passing via PLAYWRIGHT_COMMAND_LINE_OPTIONS -- for use in containers
* Update test/e2e/README.md yarn script names in "Getting started" section