### PR TITLE
Update homepage_en.html for NYUAD and NYUSH dev and prod views

### DIFF
--- a/custom/01NYU_AD-AD/html/homepage/homepage_en.html
+++ b/custom/01NYU_AD-AD/html/homepage/homepage_en.html
@@ -1,94 +1,7 @@
 <md-content layout-xs="column" layout="row" class="_md md-primoExplore-theme layout-xs-column layout-row">
     <div flex="60" layout="column" class="layout-column flex-60">
-        <!---Harmful Language Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-harmful-language">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Help Us Replace Harmful Language and Outdated Subject Headings in the
-                        Catalog</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject"
-                        target="_blank" class="md-primoExplore-theme">Changing the
-                        Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
-                    catalog.</p>
-                <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank"
-                            class="md-primoExplore-theme">Report harmful language via the online form</a>, or
-                        through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
-            </md-card-content>
-        </md-card>
-
-        <!---Collection Access Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-collections-access">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Collections Access</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <ul class="no-bullet">
-                    <li><b>In-person access to library stacks:</b> If an item says "Available" in one of our
-                        libraries, you may get items directly from the stacks (does not include "Offsite" items).
-                    </li>
-                    <li>Requesting for locker pick-up, delivery, or digital scan is available, but may not be your
-                        fastest option. For details, visit the <a
-                            href="https://library.nyu.edu/nyu-returns/collections-access/" target="_blank"
-                            class="md-primoExplore-theme">Collections Access page</a>.</li>
-                </ul>
-                <h3 class="md-subhead">What option should I choose?</h3>
-                <ul>
-                    <li><b>If you need your item today</b> and it is "Available" in the catalog, you can go directly
-                        to the stacks and get the item off the shelf. <a
-                            href="https://library.nyu.edu/about/collections/search-collections/call-numbers/"
-                            target="_blank" class="md-primoExplore-theme">Use our maps to help navigate the
-                            stacks</a>.</li>
-                    <li><b>If you can wait 3-5 days</b>, request locker pick-up.</li>
-                    <li>If there is no digital version and you do not need the full item, request a scan of 1-2
-                        chapters. </li>
-                </ul>
-            </md-card-content>
-        </md-card>
-
-        <!---Need Help? Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Need Help?</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <p>Use <a href="https://library.nyu.edu/ask/" target="_blank" class="md-primoExplore-theme">Ask A
-                        Librarian</a> or the "Chat with Us" icon at the bottom right corner for any question you
-                    have about the Libraries' services.</p>
-                <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/finding-sources" target="_blank"
-                        class="md-primoExplore-theme">online tutorials</a> for tips on searching the catalog and
-                    getting library resources.</p>
-                <h3 class="md-subhead">Additional Resources</h3>
-                <ul>
-                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank"
-                            class="md-primoExplore-theme">EZBorrow</a> or <a
-                            href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/"
-                            target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials
-                        unavailable at NYU</li>
-                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank"
-                            class="md-primoExplore-theme">expert curated research guides</a></li>
-                    <li>Explore the <a href="https://library.nyu.edu/services/" target="_blank"
-                            class="md-primoExplore-theme">complete list of library services</a></li>
-                    <li>Reach out to the Libraries on <a href="https://www.instagram.com/nyulibraries/" target="_blank"
-                            class="md-primoExplore-theme">our Instagram</a></li>
-                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank"
-                            class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
-                </ul>
-            </md-card-content>
-        </md-card>
 
 
-
-
-
-    </div>
-    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
         <!---Using the Catalog Card--->
         <md-card class="default-card _md md-primoExplore-theme">
             <md-card-title>
@@ -97,37 +10,98 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-                <h3 class="md-subhead">What is in Books &amp; More?</h3>
+                <h3 class="md-subhead">What's in the Catalog Search?</h3>
                 <p>Using the search bar on this page, you can find:</p>
                 <ul>
                     <li>books / e-books</li>
+                    <li>scholarly articles</li>
                     <li>journals / e-journals</li>
+                    <li>newspapers and magazine articles</li>
+                    <li>scores and scripts</li>
                     <li>videos and sound recordings</li>
                     <li>offsite materials</li>
                     <li>special collections</li>
                 </ul>
-                <h3 class="md-subhead">Tools to help with your search:</h3>
-                <ul>
-                    <li><a href="https://guides.nyu.edu/online-tutorials/finding-sources#s-lg-box-25062803"
-                            target="_blank" class="md-primoExplore-theme">online tutorials for using the catalog</a>
-                    </li>
-                    <li><a href="/discovery/jsearch?vid=01NYU_AD:AD"
-                            class="md-primoExplore-theme">browse journals by title</a></li>
-                    <li><a href="/discovery/citationlinker?vid=01NYU_AD:AD"
-                            class="md-primoExplore-theme">find an article by citation</a></li>
-                </ul>
                 <p>Resources are across all of NYU’s Abu Dhabi and global libraries.</p>
-                <h3 class="md-subhead">Looking for Articles or Databases?</h3>
-                <p>Use the Articles &amp; Databases tab to find:</p>
-                <ul class="bottom-margin">
-                    <li>articles from multidisciplinary databases</li>
-                    <li>databases by title or by subject area</li>
-                </ul>
-                <div>
-                    <p>Note: For these resources, you must use the Articles &amp; Databases tab, and <b>not</b> the
-                        search bar on this screen.</p>
-                </div>
+
+
+
+                <h4 class="md-subhead">Tools to help with your search:</h4>
+                <ul>
+                    <li><a href="https://guides.nyu.edu/nyu-ad-catalog" target="_blank">Guide to Using the NYUAD Catalog</a></li>
+                    <ul>
+                        <li><a href="https://guides.nyu.edu/nyu-ad-catalog/requesting-materials" target="_blank">Requesting Materials</a></li>
+                        <li><a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank">Article Searching</a></li><a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank">
+                    </a><li><a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank"></a><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank">Saved Items and Searches</a></li><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank">
+                    </a></ul><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank">
+                </a><li><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank"></a><a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">Tutorials from NYUNY</a>
+                </li></ul>
+
+
+
+
+
             </md-card-content>
         </md-card>
+
+
+
+
+
+        <!---Harmful Langauge Card---><md-card class="default-card _md md-primoExplore-theme" data-cy="home-harmful-language">
+        <md-card-title>
+            <md-card-title-text>
+                <h2 class="md-headline">Help Us Replace Harmful Language and Outdated Subject Headings in the
+                    Catalog</h2>
+            </md-card-title-text>
+        </md-card-title>
+        <md-card-content>
+            <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject" target="_blank" class="md-primoExplore-theme">Changing the
+                Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
+                catalog.</p>
+            <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank" class="md-primoExplore-theme">Report harmful language via the online form</a>, or
+                through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
+        </md-card-content>
+    </md-card><!---Right Column--->
+    </div>
+    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
+
+        <!---Need Help Card--->
+        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
+            <md-card-title>
+                <md-card-title-text>
+                    <h2 class="md-headline">Need Help?</h2>
+                </md-card-title-text>
+            </md-card-title>
+            <md-card-content>
+                <p>Visit our <a href="https://nyuad.nyu.edu/en/library/using-the-library/contact/contact-the-library.html" target="_blank">Contact Us</a> page or use the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.</p>
+                <p>Visit the <a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">Using NYUAD Library's Catalog guide</a> for tips on searching the catalog and getting library resources.</p>
+                <h3 class="md-subhead">Additional Resources</h3>
+                <ul>
+                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank" class="md-primoExplore-theme">EZBorrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials unavailable at NYU</li>
+                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank" class="md-primoExplore-theme">expert-curated research guides</a></li>
+                    <li>Explore library services available through our <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/faculty-resources.html" target="_blank">faculty and staff resources</a>, and <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/student-resources.html" target="_blank">student resources</a></li>
+                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank" class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
+                    <li>Follow the <a href="https://www.instagram.com/nyuadlibrary/" target="_blank" class="md-primoExplore-theme">NYU Abu Dhabi Library Instagram</a> to keep in the know about library events, services, and collections.</li>
+                </ul>
+            </md-card-content>
+        </md-card>
+        <!---Collection Access Card---><md-card class="default-card _md md-primoExplore-theme" data-cy="home-collections-access">
+        <md-card-title>
+            <md-card-title-text>
+                <h2 class="md-headline">Collections Access</h2>
+            </md-card-title-text>
+        </md-card-title>
+        <md-card-content>
+            <h3 class="md-subhead">In-person access to library stacks:</h3>
+            <p>If an item says "Available" (in green text) at our library, you may get it directly from the stacks. For details, visit the <a href="https://nyuad.nyu.edu/en/library/using-the-library/borrow-renew-return.html" target="_blank">Borrow and Request page</a>.</p>
+
+            <h3 class="md-subhead"><a href="https://guides.nyu.edu/nyu-ad-catalog/availability-information" target="_blank">Availabilty Status Definitons and What To Do </a>
+        </md-card-content>
+    </md-card>
     </div>
 </md-content>
+
+
+
+

--- a/custom/01NYU_AD-AD_DEV/html/homepage/homepage_en.html
+++ b/custom/01NYU_AD-AD_DEV/html/homepage/homepage_en.html
@@ -1,94 +1,7 @@
 <md-content layout-xs="column" layout="row" class="_md md-primoExplore-theme layout-xs-column layout-row">
     <div flex="60" layout="column" class="layout-column flex-60">
-        <!---Harmful Language Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-harmful-language">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Help Us Replace Harmful Language and Outdated Subject Headings in the
-                        Catalog</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject"
-                        target="_blank" class="md-primoExplore-theme">Changing the
-                        Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
-                    catalog.</p>
-                <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank"
-                            class="md-primoExplore-theme">Report harmful language via the online form</a>, or
-                        through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
-            </md-card-content>
-        </md-card>
-
-        <!---Collection Access Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-collections-access">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Collections Access</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <ul class="no-bullet">
-                    <li><b>In-person access to library stacks:</b> If an item says "Available" in one of our
-                        libraries, you may get items directly from the stacks (does not include "Offsite" items).
-                    </li>
-                    <li>Requesting for locker pick-up, delivery, or digital scan is available, but may not be your
-                        fastest option. For details, visit the <a
-                            href="https://library.nyu.edu/nyu-returns/collections-access/" target="_blank"
-                            class="md-primoExplore-theme">Collections Access page</a>.</li>
-                </ul>
-                <h3 class="md-subhead">What option should I choose?</h3>
-                <ul>
-                    <li><b>If you need your item today</b> and it is "Available" in the catalog, you can go directly
-                        to the stacks and get the item off the shelf. <a
-                            href="https://library.nyu.edu/about/collections/search-collections/call-numbers/"
-                            target="_blank" class="md-primoExplore-theme">Use our maps to help navigate the
-                            stacks</a>.</li>
-                    <li><b>If you can wait 3-5 days</b>, request locker pick-up.</li>
-                    <li>If there is no digital version and you do not need the full item, request a scan of 1-2
-                        chapters. </li>
-                </ul>
-            </md-card-content>
-        </md-card>
-
-        <!---Need Help? Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Need Help?</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <p>Use <a href="https://library.nyu.edu/ask/" target="_blank" class="md-primoExplore-theme">Ask A
-                        Librarian</a> or the "Chat with Us" icon at the bottom right corner for any question you
-                    have about the Libraries' services.</p>
-                <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/finding-sources" target="_blank"
-                        class="md-primoExplore-theme">online tutorials</a> for tips on searching the catalog and
-                    getting library resources.</p>
-                <h3 class="md-subhead">Additional Resources</h3>
-                <ul>
-                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank"
-                            class="md-primoExplore-theme">EZBorrow</a> or <a
-                            href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/"
-                            target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials
-                        unavailable at NYU</li>
-                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank"
-                            class="md-primoExplore-theme">expert curated research guides</a></li>
-                    <li>Explore the <a href="https://library.nyu.edu/services/" target="_blank"
-                            class="md-primoExplore-theme">complete list of library services</a></li>
-                    <li>Reach out to the Libraries on <a href="https://www.instagram.com/nyulibraries/" target="_blank"
-                            class="md-primoExplore-theme">our Instagram</a></li>
-                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank"
-                            class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
-                </ul>
-            </md-card-content>
-        </md-card>
 
 
-
-
-
-    </div>
-    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
         <!---Using the Catalog Card--->
         <md-card class="default-card _md md-primoExplore-theme">
             <md-card-title>
@@ -97,37 +10,98 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-                <h3 class="md-subhead">What is in Books &amp; More?</h3>
+                <h3 class="md-subhead">What's in the Catalog Search?</h3>
                 <p>Using the search bar on this page, you can find:</p>
                 <ul>
                     <li>books / e-books</li>
+                    <li>scholarly articles</li>
                     <li>journals / e-journals</li>
+                    <li>newspapers and magazine articles</li>
+                    <li>scores and scripts</li>
                     <li>videos and sound recordings</li>
                     <li>offsite materials</li>
                     <li>special collections</li>
                 </ul>
-                <h3 class="md-subhead">Tools to help with your search:</h3>
+                <p>Resources are across all of NYU’s Abu Dhabi and global libraries.</p>
+
+
+
+                <h4 class="md-subhead">Tools to help with your search:</h4>
                 <ul>
-                    <li><a href="https://guides.nyu.edu/online-tutorials/finding-sources#s-lg-box-25062803"
-                            target="_blank" class="md-primoExplore-theme">online tutorials for using the catalog</a>
-                    </li>
-                    <li><a href="/discovery/jsearch?vid=01NYU_AD:AD_DEV"
-                            class="md-primoExplore-theme">browse journals by title</a></li>
-                    <li><a href="/discovery/citationlinker?vid=01NYU_AD:AD_DEV"
-                            class="md-primoExplore-theme">find an article by citation</a></li>
-                </ul>
-                <p>Resources are across all of NYU’s [Abu Dhabi DEV] and global libraries.</p>
-                <h3 class="md-subhead">Looking for Articles or Databases?</h3>
-                <p>Use the Articles &amp; Databases tab to find:</p>
-                <ul class="bottom-margin">
-                    <li>articles from multidisciplinary databases</li>
-                    <li>databases by title or by subject area</li>
-                </ul>
-                <div>
-                    <p>Note: For these resources, you must use the Articles &amp; Databases tab, and <b>not</b> the
-                        search bar on this screen.</p>
-                </div>
+                    <li><a href="https://guides.nyu.edu/nyu-ad-catalog" target="_blank">Guide to Using the NYUAD Catalog</a></li>
+                    <ul>
+                        <li><a href="https://guides.nyu.edu/nyu-ad-catalog/requesting-materials" target="_blank">Requesting Materials</a></li>
+                        <li><a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank">Article Searching</a></li><a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank">
+                    </a><li><a href="https://guides.nyu.edu/nyu-ad-catalog/article-searching" target="_blank"></a><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank">Saved Items and Searches</a></li><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank">
+                    </a></ul><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank">
+                </a><li><a href="https://guides.nyu.edu/nyu-ad-catalog/saved-items-and-searches" target="_blank"></a><a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">Tutorials from NYUNY</a>
+                </li></ul>
+
+
+
+
+
             </md-card-content>
         </md-card>
+
+
+
+
+
+        <!---Harmful Langauge Card---><md-card class="default-card _md md-primoExplore-theme" data-cy="home-harmful-language">
+        <md-card-title>
+            <md-card-title-text>
+                <h2 class="md-headline">Help Us Replace Harmful Language and Outdated Subject Headings in the
+                    Catalog</h2>
+            </md-card-title-text>
+        </md-card-title>
+        <md-card-content>
+            <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject" target="_blank" class="md-primoExplore-theme">Changing the
+                Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
+                catalog.</p>
+            <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank" class="md-primoExplore-theme">Report harmful language via the online form</a>, or
+                through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
+        </md-card-content>
+    </md-card><!---Right Column--->
+    </div>
+    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
+
+        <!---Need Help Card--->
+        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
+            <md-card-title>
+                <md-card-title-text>
+                    <h2 class="md-headline">Need Help?</h2>
+                </md-card-title-text>
+            </md-card-title>
+            <md-card-content>
+                <p>Visit our <a href="https://nyuad.nyu.edu/en/library/using-the-library/contact/contact-the-library.html" target="_blank">Contact Us</a> page or use the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.</p>
+                <p>Visit the <a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">Using NYUAD Library's Catalog guide</a> for tips on searching the catalog and getting library resources.</p>
+                <h3 class="md-subhead">Additional Resources</h3>
+                <ul>
+                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank" class="md-primoExplore-theme">EZBorrow</a> or <a href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/" target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials unavailable at NYU</li>
+                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank" class="md-primoExplore-theme">expert-curated research guides</a></li>
+                    <li>Explore library services available through our <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/faculty-resources.html" target="_blank">faculty and staff resources</a>, and <a href="https://nyuad.nyu.edu/en/library/research-and-instruction-services/student-resources.html" target="_blank">student resources</a></li>
+                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank" class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
+                    <li>Follow the <a href="https://www.instagram.com/nyuadlibrary/" target="_blank" class="md-primoExplore-theme">NYU Abu Dhabi Library Instagram</a> to keep in the know about library events, services, and collections.</li>
+                </ul>
+            </md-card-content>
+        </md-card>
+        <!---Collection Access Card---><md-card class="default-card _md md-primoExplore-theme" data-cy="home-collections-access">
+        <md-card-title>
+            <md-card-title-text>
+                <h2 class="md-headline">Collections Access</h2>
+            </md-card-title-text>
+        </md-card-title>
+        <md-card-content>
+            <h3 class="md-subhead">In-person access to library stacks:</h3>
+            <p>If an item says "Available" (in green text) at our library, you may get it directly from the stacks. For details, visit the <a href="https://nyuad.nyu.edu/en/library/using-the-library/borrow-renew-return.html" target="_blank">Borrow and Request page</a>.</p>
+
+            <h3 class="md-subhead"><a href="https://guides.nyu.edu/nyu-ad-catalog/availability-information" target="_blank">Availabilty Status Definitons and What To Do </a>
+        </md-card-content>
+    </md-card>
     </div>
 </md-content>
+
+
+
+

--- a/custom/01NYU_US-SH/html/homepage/homepage_en.html
+++ b/custom/01NYU_US-SH/html/homepage/homepage_en.html
@@ -1,6 +1,50 @@
 <md-content layout-xs="column" layout="row" class="_md md-primoExplore-theme layout-xs-column layout-row">
     <div flex="60" layout="column" class="layout-column flex-60">
+
+
+        <!---Using the Catalog Card--->
+        <md-card class="default-card _md md-primoExplore-theme">
+            <md-card-title>
+                <md-card-title-text>
+                    <h2 class="md-headline">Using the Catalog</h2>
+                </md-card-title-text>
+            </md-card-title>
+            <md-card-content>
+                <h3 class="md-subhead">What's in the Catalog Search?</h3>
+                <p>Using the search bar on this page, you can find:</p>
+                <ul>
+                    <li>books / e-books</li>
+                    <li>scholarly articles</li>
+                    <li>journals / e-journals</li>
+                    <li>newspapers and magazine articles</li>
+                    <li>scores and scripts</li>
+                    <li>videos and sound recordings</li>
+                    <li>offsite materials</li>
+                    <li>special collections</li>
+                </ul>
+                <h3 class="md-subhead">Search Scopes</h3>
+                <ul><li>All at Shanghai</li><ul><li>physical books, eBooks, journals, video &amp;  audio sources, scores, in addition to individual articles, e-book chapters, dissertations, etc. at NYU Shanghai Library</li></ul>
+                    <li>All at NYU</li><ul><li>physical books, eBooks, journals, video &amp; audio sources, scores, in addition to individual articles, e-book chapters, archival materials, dissertations, etc. at NYU global libraries</li></ul>
+                    <li>Articles</li><ul><li>While this search captures most of the journal articles NYU Libraries subscribe to, there are some e-resources that may not come up.</li></ul>
+                    <li>Classic Search</li><ul><li>physical books, eBooks, journals, video sources &amp; sources etc. at NYU Shanghai Library (individual journal articles &amp; ebook chapters excluded)</li></ul></ul>
+                <h3 class="md-subhead">Tools to help with your search:</h3>
+                <ul>
+                    <li><a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">online tutorials for using the catalog</a>
+                    </li>
+                    <li><a href="/discovery/jsearch?vid=01NYU_US:SH" class="md-primoExplore-theme">browse journals by title</a></li>
+                    <li><a href="/discovery/citationlinker?vid=01NYU_US:SH" class="md-primoExplore-theme">find an article by citation</a></li>
+                </ul>
+                <h2 class="md-headline">Advanced Database Searching Beyond the Catalog</h2>
+                <p>For more sophisticated inquiries that go beyond our extensive catalog search, use the <a href="https://guides.nyu.edu/arch" target="_blank">Articles &amp; Databases</a> tab to find:
+                </p><ul>
+                <li>articles from multidisciplinary databases</li>
+                <li>databases by title or by subject area</li>
+            </ul>
+                <p></p>
+            </md-card-content>
+        </md-card>
         <!---Harmful Language Card--->
+
         <md-card class="default-card _md md-primoExplore-theme" data-cy="home-harmful-language">
             <md-card-title>
                 <md-card-title-text>
@@ -9,13 +53,35 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-                <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject"
-                        target="_blank" class="md-primoExplore-theme">Changing the
-                        Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
+                <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject" target="_blank" class="md-primoExplore-theme">Changing the
+                    Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
                     catalog.</p>
-                <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank"
-                            class="md-primoExplore-theme">Report harmful language via the online form</a>, or
-                        through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
+                <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank" class="md-primoExplore-theme">Report harmful language via the online form</a>, or
+                    through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
+            </md-card-content>
+        </md-card>
+
+        <!---Right Column--->
+    </div>
+    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
+
+        <!---Need Help Card--->
+        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
+            <md-card-title>
+                <md-card-title-text>
+                    <h2 class="md-headline">Need Help?</h2>
+                </md-card-title-text>
+            </md-card-title>
+            <md-card-content>
+                <p>Use <a href="https://library.shanghai.nyu.edu/aal" target="_blank">Ask a Librarian</a> or the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.</p>
+                <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank">online tutorials</a> for tips on searching the catalog and getting library resources.</p>
+                <h3 class="md-subhead">Additional Resources</h3>
+                <ul>
+                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu/" target="_blank">research guides curated by expert librarians across all NYU</a>.</li>
+                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank" class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
+                    <li>Browse our <a href="https://library.answers.nyu.edu/search/?t=0&amp;g=369&amp;topics=NYU%20Shanghai&amp;adv=1" target="_blank">FAQ</a> to find helpful answers to common inquiries.</li>
+                    <li>Follow us on the <a href="https://library-blog.shanghai.nyu.edu/2023/01/01/contact-us/" target="_blank">NYU Shanghai Library Instagram and WeChat</a>.</li>
+                </ul>
             </md-card-content>
         </md-card>
 
@@ -27,107 +93,16 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-                <ul class="no-bullet">
-                    <li><b>In-person access to library stacks:</b> If an item says "Available" in one of our
-                        libraries, you may get items directly from the stacks (does not include "Offsite" items).
-                    </li>
-                    <li>Requesting for locker pick-up, delivery, or digital scan is available, but may not be your
-                        fastest option. For details, visit the <a
-                            href="https://library.nyu.edu/nyu-returns/collections-access/" target="_blank"
-                            class="md-primoExplore-theme">Collections Access page</a>.</li>
-                </ul>
-                <h3 class="md-subhead">What option should I choose?</h3>
                 <ul>
-                    <li><b>If you need your item today</b> and it is "Available" in the catalog, you can go directly
-                        to the stacks and get the item off the shelf. <a
-                            href="https://library.nyu.edu/about/collections/search-collections/call-numbers/"
-                            target="_blank" class="md-primoExplore-theme">Use our maps to help navigate the
-                            stacks</a>.</li>
-                    <li><b>If you can wait 3-5 days</b>, request locker pick-up.</li>
-                    <li>If there is no digital version and you do not need the full item, request a scan of 1-2
-                        chapters. </li>
+                    <li>In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks. Use <a href="https://library.shanghai.nyu.edu/floor-map" target="_blank">our floor map to navigate the stacks</a>.</li>
+                    <li>For items only available in print in New York, you may request a single chapter scan.</li>
+                    <li>Any other chapter scan requests may be submitted via <a href="https://ill.library.nyu.edu/" target="_blank">Interlibrary Loan (ILL)</a>.</li>
+                    <li>If you require an entire book that is not available in the NYU Shanghai Collection, <a href="https://ill.library.nyu.edu/" target="_blank">place an Interlibrary Loan request</a>.</li>
                 </ul>
-            </md-card-content>
-        </md-card>
-
-        <!---Need Help? Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Need Help?</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <p>Use <a href="https://library.nyu.edu/ask/" target="_blank" class="md-primoExplore-theme">Ask A
-                        Librarian</a> or the "Chat with Us" icon at the bottom right corner for any question you
-                    have about the Libraries' services.</p>
-                <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/finding-sources" target="_blank"
-                        class="md-primoExplore-theme">online tutorials</a> for tips on searching the catalog and
-                    getting library resources.</p>
-                <h3 class="md-subhead">Additional Resources</h3>
-                <ul>
-                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank"
-                            class="md-primoExplore-theme">EZBorrow</a> or <a
-                            href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/"
-                            target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials
-                        unavailable at NYU</li>
-                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank"
-                            class="md-primoExplore-theme">expert curated research guides</a></li>
-                    <li>Explore the <a href="https://library.nyu.edu/services/" target="_blank"
-                            class="md-primoExplore-theme">complete list of library services</a></li>
-                    <li>Reach out to the Libraries on <a href="https://www.instagram.com/nyulibraries/" target="_blank"
-                            class="md-primoExplore-theme">our Instagram</a></li>
-                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank"
-                            class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
-                </ul>
+                <p></p>
             </md-card-content>
         </md-card>
 
 
-
-
-
-    </div>
-    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
-        <!---Using the Catalog Card--->
-        <md-card class="default-card _md md-primoExplore-theme">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Using the Catalog</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <h3 class="md-subhead">What is in Books &amp; More?</h3>
-                <p>Using the search bar on this page, you can find:</p>
-                <ul>
-                    <li>books / e-books</li>
-                    <li>journals / e-journals</li>
-                    <li>videos and sound recordings</li>
-                    <li>offsite materials</li>
-                    <li>special collections</li>
-                </ul>
-                <h3 class="md-subhead">Tools to help with your search:</h3>
-                <ul>
-                    <li><a href="https://guides.nyu.edu/online-tutorials/finding-sources#s-lg-box-25062803"
-                            target="_blank" class="md-primoExplore-theme">online tutorials for using the catalog</a>
-                    </li>
-                    <li><a href="/discovery/jsearch?vid=01NYU_US:SH"
-                            class="md-primoExplore-theme">browse journals by title</a></li>
-                    <li><a href="/discovery/citationlinker?vid=01NYU_US:SH"
-                            class="md-primoExplore-theme">find an article by citation</a></li>
-                </ul>
-                <p>Resources are across all of NYU’s Shanghai and global libraries.</p>
-                <h3 class="md-subhead">Looking for Articles or Databases?</h3>
-                <p>Use the Articles &amp; Databases tab to find:</p>
-                <ul class="bottom-margin">
-                    <li>articles from multidisciplinary databases</li>
-                    <li>databases by title or by subject area</li>
-                </ul>
-                <div>
-                    <p>Note: For these resources, you must use the Articles &amp; Databases tab, and <b>not</b> the
-                        search bar on this screen.</p>
-                </div>
-            </md-card-content>
-        </md-card>
     </div>
 </md-content>

--- a/custom/01NYU_US-SH_DEV/html/homepage/homepage_en.html
+++ b/custom/01NYU_US-SH_DEV/html/homepage/homepage_en.html
@@ -1,6 +1,50 @@
 <md-content layout-xs="column" layout="row" class="_md md-primoExplore-theme layout-xs-column layout-row">
     <div flex="60" layout="column" class="layout-column flex-60">
+
+
+        <!---Using the Catalog Card--->
+        <md-card class="default-card _md md-primoExplore-theme">
+            <md-card-title>
+                <md-card-title-text>
+                    <h2 class="md-headline">Using the Catalog</h2>
+                </md-card-title-text>
+            </md-card-title>
+            <md-card-content>
+                <h3 class="md-subhead">What's in the Catalog Search?</h3>
+                <p>Using the search bar on this page, you can find:</p>
+                <ul>
+                    <li>books / e-books</li>
+                    <li>scholarly articles</li>
+                    <li>journals / e-journals</li>
+                    <li>newspapers and magazine articles</li>
+                    <li>scores and scripts</li>
+                    <li>videos and sound recordings</li>
+                    <li>offsite materials</li>
+                    <li>special collections</li>
+                </ul>
+                <h3 class="md-subhead">Search Scopes</h3>
+                <ul><li>All at Shanghai</li><ul><li>physical books, eBooks, journals, video &amp;  audio sources, scores, in addition to individual articles, e-book chapters, dissertations, etc. at NYU Shanghai Library</li></ul>
+                    <li>All at NYU</li><ul><li>physical books, eBooks, journals, video &amp; audio sources, scores, in addition to individual articles, e-book chapters, archival materials, dissertations, etc. at NYU global libraries</li></ul>
+                    <li>Articles</li><ul><li>While this search captures most of the journal articles NYU Libraries subscribe to, there are some e-resources that may not come up.</li></ul>
+                    <li>Classic Search</li><ul><li>physical books, eBooks, journals, video sources &amp; sources etc. at NYU Shanghai Library (individual journal articles &amp; ebook chapters excluded)</li></ul></ul>
+                <h3 class="md-subhead">Tools to help with your search:</h3>
+                <ul>
+                    <li><a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank" class="md-primoExplore-theme">online tutorials for using the catalog</a>
+                    </li>
+                    <li><a href="/discovery/jsearch?vid=01NYU_US:SH_DEV" class="md-primoExplore-theme">browse journals by title</a></li>
+                    <li><a href="/discovery/citationlinker?vid=01NYU_US:SH_DEV" class="md-primoExplore-theme">find an article by citation</a></li>
+                </ul>
+                <h2 class="md-headline">Advanced Database Searching Beyond the Catalog</h2>
+                <p>For more sophisticated inquiries that go beyond our extensive catalog search, use the <a href="https://guides.nyu.edu/arch" target="_blank">Articles &amp; Databases</a> tab to find:
+                </p><ul>
+                <li>articles from multidisciplinary databases</li>
+                <li>databases by title or by subject area</li>
+            </ul>
+                <p></p>
+            </md-card-content>
+        </md-card>
         <!---Harmful Language Card--->
+
         <md-card class="default-card _md md-primoExplore-theme" data-cy="home-harmful-language">
             <md-card-title>
                 <md-card-title-text>
@@ -9,13 +53,35 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-                <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject"
-                        target="_blank" class="md-primoExplore-theme">Changing the
-                        Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
+                <p>NYU Libraries has launched the <a href="https://tinyurl.com/nyu-lib-changing-the-subject" target="_blank" class="md-primoExplore-theme">Changing the
+                    Subject project (Google Doc)</a> to remove harmful and outdated subject headings in our
                     catalog.</p>
-                <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank"
-                            class="md-primoExplore-theme">Report harmful language via the online form</a>, or
-                        through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
+                <p><b><a href="https://tinyurl.com/nyu-lib-harmful-language-form" target="_blank" class="md-primoExplore-theme">Report harmful language via the online form</a>, or
+                    through the "Provide Feedback" link in the submenu of every page in the catalog.</b></p>
+            </md-card-content>
+        </md-card>
+
+        <!---Right Column--->
+    </div>
+    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
+
+        <!---Need Help Card--->
+        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
+            <md-card-title>
+                <md-card-title-text>
+                    <h2 class="md-headline">Need Help?</h2>
+                </md-card-title-text>
+            </md-card-title>
+            <md-card-content>
+                <p>Use <a href="https://library.shanghai.nyu.edu/aal" target="_blank">Ask a Librarian</a> or the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.</p>
+                <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/books-and-articles" target="_blank">online tutorials</a> for tips on searching the catalog and getting library resources.</p>
+                <h3 class="md-subhead">Additional Resources</h3>
+                <ul>
+                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu/" target="_blank">research guides curated by expert librarians across all NYU</a>.</li>
+                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank" class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
+                    <li>Browse our <a href="https://library.answers.nyu.edu/search/?t=0&amp;g=369&amp;topics=NYU%20Shanghai&amp;adv=1" target="_blank">FAQ</a> to find helpful answers to common inquiries.</li>
+                    <li>Follow us on the <a href="https://library-blog.shanghai.nyu.edu/2023/01/01/contact-us/" target="_blank">NYU Shanghai Library Instagram and WeChat</a>.</li>
+                </ul>
             </md-card-content>
         </md-card>
 
@@ -27,107 +93,16 @@
                 </md-card-title-text>
             </md-card-title>
             <md-card-content>
-                <ul class="no-bullet">
-                    <li><b>In-person access to library stacks:</b> If an item says "Available" in one of our
-                        libraries, you may get items directly from the stacks (does not include "Offsite" items).
-                    </li>
-                    <li>Requesting for locker pick-up, delivery, or digital scan is available, but may not be your
-                        fastest option. For details, visit the <a
-                            href="https://library.nyu.edu/nyu-returns/collections-access/" target="_blank"
-                            class="md-primoExplore-theme">Collections Access page</a>.</li>
-                </ul>
-                <h3 class="md-subhead">What option should I choose?</h3>
                 <ul>
-                    <li><b>If you need your item today</b> and it is "Available" in the catalog, you can go directly
-                        to the stacks and get the item off the shelf. <a
-                            href="https://library.nyu.edu/about/collections/search-collections/call-numbers/"
-                            target="_blank" class="md-primoExplore-theme">Use our maps to help navigate the
-                            stacks</a>.</li>
-                    <li><b>If you can wait 3-5 days</b>, request locker pick-up.</li>
-                    <li>If there is no digital version and you do not need the full item, request a scan of 1-2
-                        chapters. </li>
+                    <li>In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks. Use <a href="https://library.shanghai.nyu.edu/floor-map" target="_blank">our floor map to navigate the stacks</a>.</li>
+                    <li>For items only available in print in New York, you may request a single chapter scan.</li>
+                    <li>Any other chapter scan requests may be submitted via <a href="https://ill.library.nyu.edu/" target="_blank">Interlibrary Loan (ILL)</a>.</li>
+                    <li>If you require an entire book that is not available in the NYU Shanghai Collection, <a href="https://ill.library.nyu.edu/" target="_blank">place an Interlibrary Loan request</a>.</li>
                 </ul>
-            </md-card-content>
-        </md-card>
-
-        <!---Need Help? Card--->
-        <md-card class="default-card _md md-primoExplore-theme" data-cy="home-need-help">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Need Help?</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <p>Use <a href="https://library.nyu.edu/ask/" target="_blank" class="md-primoExplore-theme">Ask A
-                        Librarian</a> or the "Chat with Us" icon at the bottom right corner for any question you
-                    have about the Libraries' services.</p>
-                <p>Visit our <a href="https://guides.nyu.edu/online-tutorials/finding-sources" target="_blank"
-                        class="md-primoExplore-theme">online tutorials</a> for tips on searching the catalog and
-                    getting library resources.</p>
-                <h3 class="md-subhead">Additional Resources</h3>
-                <ul>
-                    <li>Use <a href="https://ezborrow.reshare.indexdata.com/" target="_blank"
-                            class="md-primoExplore-theme">EZBorrow</a> or <a
-                            href="https://library.nyu.edu/services/borrowing/from-non-nyu-libraries/interlibrary-loan/"
-                            target="_blank" class="md-primoExplore-theme">InterLibrary Loan (ILL)</a> for materials
-                        unavailable at NYU</li>
-                    <li>Discover subject specific resources using <a href="http://guides.nyu.edu" target="_blank"
-                            class="md-primoExplore-theme">expert curated research guides</a></li>
-                    <li>Explore the <a href="https://library.nyu.edu/services/" target="_blank"
-                            class="md-primoExplore-theme">complete list of library services</a></li>
-                    <li>Reach out to the Libraries on <a href="https://www.instagram.com/nyulibraries/" target="_blank"
-                            class="md-primoExplore-theme">our Instagram</a></li>
-                    <li>Search <a href="https://www.worldcat.org/search?qt=worldcat_org_all" target="_blank"
-                            class="md-primoExplore-theme">WorldCat</a> for items in nearby libraries</li>
-                </ul>
+                <p></p>
             </md-card-content>
         </md-card>
 
 
-
-
-
-    </div>
-    <div flex-xs="" flex="40" layout="column" class="layout-column flex-xs flex-40">
-        <!---Using the Catalog Card--->
-        <md-card class="default-card _md md-primoExplore-theme">
-            <md-card-title>
-                <md-card-title-text>
-                    <h2 class="md-headline">Using the Catalog</h2>
-                </md-card-title-text>
-            </md-card-title>
-            <md-card-content>
-                <h3 class="md-subhead">What is in Books &amp; More?</h3>
-                <p>Using the search bar on this page, you can find:</p>
-                <ul>
-                    <li>books / e-books</li>
-                    <li>journals / e-journals</li>
-                    <li>videos and sound recordings</li>
-                    <li>offsite materials</li>
-                    <li>special collections</li>
-                </ul>
-                <h3 class="md-subhead">Tools to help with your search:</h3>
-                <ul>
-                    <li><a href="https://guides.nyu.edu/online-tutorials/finding-sources#s-lg-box-25062803"
-                            target="_blank" class="md-primoExplore-theme">online tutorials for using the catalog</a>
-                    </li>
-                    <li><a href="/discovery/jsearch?vid=01NYU_US:SH_DEV"
-                            class="md-primoExplore-theme">browse journals by title</a></li>
-                    <li><a href="/discovery/citationlinker?vid=01NYU_US:SH_DEV"
-                            class="md-primoExplore-theme">find an article by citation</a></li>
-                </ul>
-                <p>Resources are across all of NYU’s [Shanghai DEV] and global libraries.</p>
-                <h3 class="md-subhead">Looking for Articles or Databases?</h3>
-                <p>Use the Articles &amp; Databases tab to find:</p>
-                <ul class="bottom-margin">
-                    <li>articles from multidisciplinary databases</li>
-                    <li>databases by title or by subject area</li>
-                </ul>
-                <div>
-                    <p>Note: For these resources, you must use the Articles &amp; Databases tab, and <b>not</b> the
-                        search bar on this screen.</p>
-                </div>
-            </md-card-content>
-        </md-card>
     </div>
 </md-content>

--- a/test/e2e/tests/golden/01NYU_AD-AD/home-page.txt
+++ b/test/e2e/tests/golden/01NYU_AD-AD/home-page.txt
@@ -1,50 +1,46 @@
+Using the Catalog
+What's in the Catalog Search?
+
+Using the search bar on this page, you can find:
+
+books / e-books
+scholarly articles
+journals / e-journals
+newspapers and magazine articles
+scores and scripts
+videos and sound recordings
+offsite materials
+special collections
+
+Resources are across all of NYU’s Abu Dhabi and global libraries.
+
+Tools to help with your search:
+Guide to Using the NYUAD Catalog
+Requesting Materials
+Article Searching
+Saved Items and Searches
+Tutorials from NYUNY
 Help Us Replace Harmful Language and Outdated Subject Headings in the Catalog
 
 NYU Libraries has launched the Changing the Subject project (Google Doc) to remove harmful and outdated subject headings in our catalog.
 
 Report harmful language via the online form, or through the "Provide Feedback" link in the submenu of every page in the catalog.
 
-Collections Access
-In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks (does not include "Offsite" items).
-Requesting for locker pick-up, delivery, or digital scan is available, but may not be your fastest option. For details, visit the Collections Access page.
-What option should I choose?
-If you need your item today and it is "Available" in the catalog, you can go directly to the stacks and get the item off the shelf. Use our maps to help navigate the stacks.
-If you can wait 3-5 days, request locker pick-up.
-If there is no digital version and you do not need the full item, request a scan of 1-2 chapters.
 Need Help?
 
-Use Ask A Librarian or the "Chat with Us" icon at the bottom right corner for any question you have about the Libraries' services.
+Visit our Contact Us page or use the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.
 
-Visit our online tutorials for tips on searching the catalog and getting library resources.
+Visit the Using NYUAD Library's Catalog guide for tips on searching the catalog and getting library resources.
 
 Additional Resources
 Use EZBorrow or InterLibrary Loan (ILL) for materials unavailable at NYU
-Discover subject specific resources using expert curated research guides
-Explore the complete list of library services
-Reach out to the Libraries on our Instagram
+Discover subject specific resources using expert-curated research guides
+Explore library services available through our faculty and staff resources, and student resources
 Search WorldCat for items in nearby libraries
-Using the Catalog
-What is in Books & More?
+Follow the NYU Abu Dhabi Library Instagram to keep in the know about library events, services, and collections.
+Collections Access
+In-person access to library stacks:
 
-Using the search bar on this page, you can find:
+If an item says "Available" (in green text) at our library, you may get it directly from the stacks. For details, visit the Borrow and Request page.
 
-books / e-books
-journals / e-journals
-videos and sound recordings
-offsite materials
-special collections
-Tools to help with your search:
-online tutorials for using the catalog
-browse journals by title
-find an article by citation
-
-Resources are across all of NYU’s Abu Dhabi and global libraries.
-
-Looking for Articles or Databases?
-
-Use the Articles & Databases tab to find:
-
-articles from multidisciplinary databases
-databases by title or by subject area
-
-Note: For these resources, you must use the Articles & Databases tab, and not the search bar on this screen.
+Availabilty Status Definitons and What To Do

--- a/test/e2e/tests/golden/01NYU_AD-AD_DEV/home-page.txt
+++ b/test/e2e/tests/golden/01NYU_AD-AD_DEV/home-page.txt
@@ -1,50 +1,46 @@
+Using the Catalog
+What's in the Catalog Search?
+
+Using the search bar on this page, you can find:
+
+books / e-books
+scholarly articles
+journals / e-journals
+newspapers and magazine articles
+scores and scripts
+videos and sound recordings
+offsite materials
+special collections
+
+Resources are across all of NYU’s Abu Dhabi and global libraries.
+
+Tools to help with your search:
+Guide to Using the NYUAD Catalog
+Requesting Materials
+Article Searching
+Saved Items and Searches
+Tutorials from NYUNY
 Help Us Replace Harmful Language and Outdated Subject Headings in the Catalog
 
 NYU Libraries has launched the Changing the Subject project (Google Doc) to remove harmful and outdated subject headings in our catalog.
 
 Report harmful language via the online form, or through the "Provide Feedback" link in the submenu of every page in the catalog.
 
-Collections Access
-In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks (does not include "Offsite" items).
-Requesting for locker pick-up, delivery, or digital scan is available, but may not be your fastest option. For details, visit the Collections Access page.
-What option should I choose?
-If you need your item today and it is "Available" in the catalog, you can go directly to the stacks and get the item off the shelf. Use our maps to help navigate the stacks.
-If you can wait 3-5 days, request locker pick-up.
-If there is no digital version and you do not need the full item, request a scan of 1-2 chapters.
 Need Help?
 
-Use Ask A Librarian or the "Chat with Us" icon at the bottom right corner for any question you have about the Libraries' services.
+Visit our Contact Us page or use the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.
 
-Visit our online tutorials for tips on searching the catalog and getting library resources.
+Visit the Using NYUAD Library's Catalog guide for tips on searching the catalog and getting library resources.
 
 Additional Resources
 Use EZBorrow or InterLibrary Loan (ILL) for materials unavailable at NYU
-Discover subject specific resources using expert curated research guides
-Explore the complete list of library services
-Reach out to the Libraries on our Instagram
+Discover subject specific resources using expert-curated research guides
+Explore library services available through our faculty and staff resources, and student resources
 Search WorldCat for items in nearby libraries
-Using the Catalog
-What is in Books & More?
+Follow the NYU Abu Dhabi Library Instagram to keep in the know about library events, services, and collections.
+Collections Access
+In-person access to library stacks:
 
-Using the search bar on this page, you can find:
+If an item says "Available" (in green text) at our library, you may get it directly from the stacks. For details, visit the Borrow and Request page.
 
-books / e-books
-journals / e-journals
-videos and sound recordings
-offsite materials
-special collections
-Tools to help with your search:
-online tutorials for using the catalog
-browse journals by title
-find an article by citation
-
-Resources are across all of NYU’s [Abu Dhabi DEV] and global libraries.
-
-Looking for Articles or Databases?
-
-Use the Articles & Databases tab to find:
-
-articles from multidisciplinary databases
-databases by title or by subject area
-
-Note: For these resources, you must use the Articles & Databases tab, and not the search bar on this screen.
+Availabilty Status Definitons and What To Do

--- a/test/e2e/tests/golden/01NYU_US-SH/home-page.txt
+++ b/test/e2e/tests/golden/01NYU_US-SH/home-page.txt
@@ -1,50 +1,55 @@
+Using the Catalog
+What's in the Catalog Search?
+
+Using the search bar on this page, you can find:
+
+books / e-books
+scholarly articles
+journals / e-journals
+newspapers and magazine articles
+scores and scripts
+videos and sound recordings
+offsite materials
+special collections
+Search Scopes
+All at Shanghai
+physical books, eBooks, journals, video & audio sources, scores, in addition to individual articles, e-book chapters, dissertations, etc. at NYU Shanghai Library
+All at NYU
+physical books, eBooks, journals, video & audio sources, scores, in addition to individual articles, e-book chapters, archival materials, dissertations, etc. at NYU global libraries
+Articles
+While this search captures most of the journal articles NYU Libraries subscribe to, there are some e-resources that may not come up.
+Classic Search
+physical books, eBooks, journals, video sources & sources etc. at NYU Shanghai Library (individual journal articles & ebook chapters excluded)
+Tools to help with your search:
+online tutorials for using the catalog
+browse journals by title
+find an article by citation
+Advanced Database Searching Beyond the Catalog
+
+For more sophisticated inquiries that go beyond our extensive catalog search, use the Articles & Databases tab to find:
+
+articles from multidisciplinary databases
+databases by title or by subject area
+
 Help Us Replace Harmful Language and Outdated Subject Headings in the Catalog
 
 NYU Libraries has launched the Changing the Subject project (Google Doc) to remove harmful and outdated subject headings in our catalog.
 
 Report harmful language via the online form, or through the "Provide Feedback" link in the submenu of every page in the catalog.
 
-Collections Access
-In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks (does not include "Offsite" items).
-Requesting for locker pick-up, delivery, or digital scan is available, but may not be your fastest option. For details, visit the Collections Access page.
-What option should I choose?
-If you need your item today and it is "Available" in the catalog, you can go directly to the stacks and get the item off the shelf. Use our maps to help navigate the stacks.
-If you can wait 3-5 days, request locker pick-up.
-If there is no digital version and you do not need the full item, request a scan of 1-2 chapters.
 Need Help?
 
-Use Ask A Librarian or the "Chat with Us" icon at the bottom right corner for any question you have about the Libraries' services.
+Use Ask a Librarian or the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.
 
 Visit our online tutorials for tips on searching the catalog and getting library resources.
 
 Additional Resources
-Use EZBorrow or InterLibrary Loan (ILL) for materials unavailable at NYU
-Discover subject specific resources using expert curated research guides
-Explore the complete list of library services
-Reach out to the Libraries on our Instagram
+Discover subject specific resources using research guides curated by expert librarians across all NYU.
 Search WorldCat for items in nearby libraries
-Using the Catalog
-What is in Books & More?
-
-Using the search bar on this page, you can find:
-
-books / e-books
-journals / e-journals
-videos and sound recordings
-offsite materials
-special collections
-Tools to help with your search:
-online tutorials for using the catalog
-browse journals by title
-find an article by citation
-
-Resources are across all of NYU’s Shanghai and global libraries.
-
-Looking for Articles or Databases?
-
-Use the Articles & Databases tab to find:
-
-articles from multidisciplinary databases
-databases by title or by subject area
-
-Note: For these resources, you must use the Articles & Databases tab, and not the search bar on this screen.
+Browse our FAQ to find helpful answers to common inquiries.
+Follow us on the NYU Shanghai Library Instagram and WeChat.
+Collections Access
+In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks. Use our floor map to navigate the stacks.
+For items only available in print in New York, you may request a single chapter scan.
+Any other chapter scan requests may be submitted via Interlibrary Loan (ILL).
+If you require an entire book that is not available in the NYU Shanghai Collection, place an Interlibrary Loan request.

--- a/test/e2e/tests/golden/01NYU_US-SH_DEV/home-page.txt
+++ b/test/e2e/tests/golden/01NYU_US-SH_DEV/home-page.txt
@@ -1,50 +1,55 @@
+Using the Catalog
+What's in the Catalog Search?
+
+Using the search bar on this page, you can find:
+
+books / e-books
+scholarly articles
+journals / e-journals
+newspapers and magazine articles
+scores and scripts
+videos and sound recordings
+offsite materials
+special collections
+Search Scopes
+All at Shanghai
+physical books, eBooks, journals, video & audio sources, scores, in addition to individual articles, e-book chapters, dissertations, etc. at NYU Shanghai Library
+All at NYU
+physical books, eBooks, journals, video & audio sources, scores, in addition to individual articles, e-book chapters, archival materials, dissertations, etc. at NYU global libraries
+Articles
+While this search captures most of the journal articles NYU Libraries subscribe to, there are some e-resources that may not come up.
+Classic Search
+physical books, eBooks, journals, video sources & sources etc. at NYU Shanghai Library (individual journal articles & ebook chapters excluded)
+Tools to help with your search:
+online tutorials for using the catalog
+browse journals by title
+find an article by citation
+Advanced Database Searching Beyond the Catalog
+
+For more sophisticated inquiries that go beyond our extensive catalog search, use the Articles & Databases tab to find:
+
+articles from multidisciplinary databases
+databases by title or by subject area
+
 Help Us Replace Harmful Language and Outdated Subject Headings in the Catalog
 
 NYU Libraries has launched the Changing the Subject project (Google Doc) to remove harmful and outdated subject headings in our catalog.
 
 Report harmful language via the online form, or through the "Provide Feedback" link in the submenu of every page in the catalog.
 
-Collections Access
-In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks (does not include "Offsite" items).
-Requesting for locker pick-up, delivery, or digital scan is available, but may not be your fastest option. For details, visit the Collections Access page.
-What option should I choose?
-If you need your item today and it is "Available" in the catalog, you can go directly to the stacks and get the item off the shelf. Use our maps to help navigate the stacks.
-If you can wait 3-5 days, request locker pick-up.
-If there is no digital version and you do not need the full item, request a scan of 1-2 chapters.
 Need Help?
 
-Use Ask A Librarian or the "Chat with Us" icon at the bottom right corner for any question you have about the Libraries' services.
+Use Ask a Librarian or the “Chat with Us” tab at the bottom of the screen for live help with any question you have about the Libraries’ services and resources.
 
 Visit our online tutorials for tips on searching the catalog and getting library resources.
 
 Additional Resources
-Use EZBorrow or InterLibrary Loan (ILL) for materials unavailable at NYU
-Discover subject specific resources using expert curated research guides
-Explore the complete list of library services
-Reach out to the Libraries on our Instagram
+Discover subject specific resources using research guides curated by expert librarians across all NYU.
 Search WorldCat for items in nearby libraries
-Using the Catalog
-What is in Books & More?
-
-Using the search bar on this page, you can find:
-
-books / e-books
-journals / e-journals
-videos and sound recordings
-offsite materials
-special collections
-Tools to help with your search:
-online tutorials for using the catalog
-browse journals by title
-find an article by citation
-
-Resources are across all of NYU’s [Shanghai DEV] and global libraries.
-
-Looking for Articles or Databases?
-
-Use the Articles & Databases tab to find:
-
-articles from multidisciplinary databases
-databases by title or by subject area
-
-Note: For these resources, you must use the Articles & Databases tab, and not the search bar on this screen.
+Browse our FAQ to find helpful answers to common inquiries.
+Follow us on the NYU Shanghai Library Instagram and WeChat.
+Collections Access
+In-person access to library stacks: If an item says "Available" in one of our libraries, you may get items directly from the stacks. Use our floor map to navigate the stacks.
+For items only available in print in New York, you may request a single chapter scan.
+Any other chapter scan requests may be submitted via Interlibrary Loan (ILL).
+If you require an entire book that is not available in the NYU Shanghai Collection, place an Interlibrary Loan request.

--- a/test/e2e/tests/view-config/primo-ve-links/01NYU_AD-AD.js
+++ b/test/e2e/tests/view-config/primo-ve-links/01NYU_AD-AD.js
@@ -1,12 +1,3 @@
-export function getLinksToTest( vid ) {
-    return [
-        {
-            text         : 'browse journals by title',
-            expectedHref : `/discovery/jsearch?vid=${ vid }`,
-        },
-        {
-            text         : 'find an article by citation',
-            expectedHref : `/discovery/citationlinker?vid=${ vid }`,
-        },
-    ];
+export function getLinksToTest() {
+    return [];
 }


### PR DESCRIPTION
* Update home page for 01NYU_AD and 01NYU_US (Shanghai) views.  monday.com: [Implement home page edits](https://nyu-lib.monday.com/boards/765008773/pulses/5202725246)
* Remove `primo-ve-links` test links for AD views -- the new home page doesn't have any links that require `vid` testing
