### PR TITLE
Chore/refactor config helpers: minor changes

### DIFF
--- a/custom/00_common/js/01-config-helpers.js
+++ b/custom/00_common/js/01-config-helpers.js
@@ -22,12 +22,12 @@ function getCdnUrl( vid ) {
 }
 
 function getBaseUrlForHostname( hostname ) {
-    const hostnameToBaseurlMap = {
+    const hostnameToBaseUrlMap = {
         'localhost'            : 'http://localhost:3000/primo-customization', // for local development
         'primo-explore-devenv' : 'http://cdn-server:3000/primo-customization', // for docker-compose
     };
 
-    return hostnameToBaseurlMap[hostname];
+    return hostnameToBaseUrlMap[hostname];
 }
 
 function getBaseUrlForVid( vid ) {

--- a/custom/00_common/js/01-config-helpers.js
+++ b/custom/00_common/js/01-config-helpers.js
@@ -14,12 +14,9 @@ function getCdnUrl( vid ) {
     const hostname = window.location.hostname;
     const view = parseViewDirectoryName( vid );
 
-    let baseUrl;
-    // some hostname have special baseurls
-    baseUrl = getBaseUrlForHostname( hostname );
-    // otherwise, base on vid
-    if ( !baseUrl )
-        baseUrl = getBaseUrlForVid( vid );
+    // In some special cases it's possible to determine the baseUrl from the
+    // hostname.
+    const baseUrl = getBaseUrlForHostname( hostname ) || getBaseUrlForVid( vid );
 
     return `${ baseUrl }/${ view }`;
 }

--- a/custom/00_common/js/01-config-helpers.js
+++ b/custom/00_common/js/01-config-helpers.js
@@ -27,8 +27,8 @@ function getCdnUrl( vid ) {
 function getBaseUrlForHostname( hostname ) {
     const hostnameToBaseurlMap = {
         //'sandbox02-na.primo.exlibrisgroup.com': 'https://d290kawcj1dea9.cloudfront.net/primo-customization', // retired sandbox hostname: superceded by nyu-psb subdomain (no special handling) in jan 2024
-        'localhost': 'http://localhost:3000/primo-customization', // for local development
-        'primo-explore-devenv': 'http://cdn-server:3000/primo-customization' // for docker-compose
+        'localhost'            : 'http://localhost:3000/primo-customization', // for local development
+        'primo-explore-devenv' : 'http://cdn-server:3000/primo-customization', // for docker-compose
     };
 
     return hostnameToBaseurlMap[hostname];

--- a/custom/00_common/js/01-config-helpers.js
+++ b/custom/00_common/js/01-config-helpers.js
@@ -23,7 +23,6 @@ function getCdnUrl( vid ) {
 
 function getBaseUrlForHostname( hostname ) {
     const hostnameToBaseurlMap = {
-        //'sandbox02-na.primo.exlibrisgroup.com': 'https://d290kawcj1dea9.cloudfront.net/primo-customization', // retired sandbox hostname: superceded by nyu-psb subdomain (no special handling) in jan 2024
         'localhost'            : 'http://localhost:3000/primo-customization', // for local development
         'primo-explore-devenv' : 'http://cdn-server:3000/primo-customization', // for docker-compose
     };


### PR DESCRIPTION
* Clear `eslint` violations
* Replace a conditional multi-assignment to variable `baseUrl` with JS-idiomatic single-assignment to const `baseUrl`
* Remove commented out obsolete sandbox entry (we can always retrieve it from version control, and the hostname is gone now, so future developers won't be confused by lack of entry)
* Rename `hostnameToBaseurlMap` -> `hostnameToBaseUrlMap` (camel-case "Url") for consistency