### PR TITLE
Remove custom CSS, JS links

### DIFF
--- a/custom/00_common/js/03-inject.js
+++ b/custom/00_common/js/03-inject.js
@@ -11,15 +11,6 @@ function injectCDNResourceTags() {
 }
 
 function injectScriptTagForCDNCustomJS() {
-    // We have decided to rename CDN custom.{css,js} files to external.{css,js}.
-    // We may not be able to deploy the package and CDN code simultaneously, so
-    // we are setting up a transition phase where we inject script tags for
-    // both custom.js and external.js.  After the CDN has been updated with
-    // new filenames, we will delete the custom.js <script> tag.s
-    const scriptCustom = document.createElement( 'script' );
-    scriptCustom.setAttribute( 'src', `${ cdnUrl }/js/custom.js` );
-    document.body.appendChild( scriptCustom )
-
     const scriptExternal = document.createElement( 'script' );
     scriptExternal.setAttribute( 'src', `${ cdnUrl }/js/external.js` );
     document.body.appendChild( scriptExternal );
@@ -28,12 +19,6 @@ function injectScriptTagForCDNCustomJS() {
 function injectLinkTagsForCDNCustomCSS() {
     [
         'app-colors.css',
-        // We have decided to rename CDN custom.{css,js} files to external.{css,js}.
-        // We may not be able to deploy the package and CDN code simultaneously, so
-        // we are setting up a transition phase where we inject link tags for
-        // both custom.css and external.css.  After the CDN has been updated with
-        // new filenames, we will delete the custom.css <link> tag.
-        'custom.css',
         'external.css',
     ].forEach( file => {
         const link = document.createElement( 'link' );


### PR DESCRIPTION
After the CDN has been updated with new `external.js` and `external.css` filenames, we delete the custom.js  `<script>`tag and the custom.css `<link>` tag.

The transition phase injected each CDN asset twice — once under its old `custom.*` name and once under its new `external.*` name. Since the CDN only ever served the `external.*` names, those duplicate tags waste two round trips on every page load, for every view, and can never succeed.

The currently deployed package still injects both, unconditionally (`06-run.js` → `app.run(() => injectCDNResourceTags())`), so the two failing requests are visible in the Network panel on every Primo page load, for every view. Removing them cannot regress anything, since nothing was ever loading.
