### PR TITLE
test/e2e/tests/view-config/libkey/: temporarily disable failing "Download via Unpaywall" test case

### DIFF
--- a/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
@@ -29,10 +29,12 @@ const testCases = [
         name         : 'docid: cdi_proquest_journals_2358492548',
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
     },
-    {
-        name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
-        pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
-    },
+    // Temporarily disabling this failing "Download via Unpaywall" test case.
+    // We will be getting a replacement docid from KARMS DAI soon.
+    // {
+    //     name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
+    //     pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
+    // },
 ];
 
 export {

--- a/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
@@ -29,10 +29,12 @@ const testCases = [
         name         : 'docid: cdi_proquest_journals_2358492548',
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
     },
-    {
-        name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
-        pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
-    },
+    // Temporarily disabling this failing "Download via Unpaywall" test case.
+    // We will be getting a replacement docid from KARMS DAI soon.
+    // {
+    //     name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
+    //     pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
+    // },
 ];
 
 export {

--- a/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
@@ -29,10 +29,12 @@ const testCases = [
         name         : 'docid: cdi_proquest_journals_2358492548',
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=default_slot&search_scope=CI_NYUSH_NYU&offset=0',
     },
-    {
-        name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
-        pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=default_slot&search_scope=CI_NYUSH_NYU&offset=0',
-    },
+    // Temporarily disabling this failing "Download via Unpaywall" test case.
+    // We will be getting a replacement docid from KARMS DAI soon.
+    // {
+    //     name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
+    //     pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
+    // },
 ];
 
 export {


### PR DESCRIPTION
The docid we were using for the "Download via Unpaywall" LibKey test case no longer seems to bring up a result.
We will be getting a replacement docid from KARMS DAI soon.
We are temporarily disabling it for now so we can update the `rollup` version to remove this vulnerability: [Arbitrary File Write via Path Traversal in Rollup 4](https://github.com/rollup/rollup/security/advisories/GHSA-mw96-cpmx-2vgc)