### PR TITLE
Integrate/rollup keep e2e

### DIFF
--- a/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
@@ -29,10 +29,6 @@ const testCases = [
         name         : 'docid: cdi_proquest_journals_2358492548',
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
     },
-    {
-        name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
-        pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
-    },
 ];
 
 export {

--- a/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
@@ -29,10 +29,6 @@ const testCases = [
         name         : 'docid: cdi_proquest_journals_2358492548',
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
     },
-    {
-        name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
-        pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
-    },
 ];
 
 export {

--- a/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
@@ -29,12 +29,9 @@ const testCases = [
         name         : 'docid: cdi_proquest_journals_2358492548',
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=default_slot&search_scope=CI_NYUSH_NYU&offset=0',
     },
-    {
-        name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
-        pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=default_slot&search_scope=CI_NYUSH_NYU&offset=0',
-    },
 ];
 
 export {
-    testCases,
+    testCases
 };
+

--- a/test/unit/yarn.lock
+++ b/test/unit/yarn.lock
@@ -390,9 +390,9 @@ react-is@^18.0.0:
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 rollup@^3.27.1:
-  version "3.29.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
-  integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
+  version "3.30.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.30.0.tgz#3fa506fee2c5ba9d540a38da87067376cd55966d"
+  integrity sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Integrates Dependabot Rollup bump (#114) with develop.

Keeps the temporary disable of the failing
"Download via Unpaywall" e2e test introduced in #115,
while preserving the e2e test files that were removed
in the Dependabot branch.

