### PR TITLE
Run `yarn eslint:fix` and update comment for temporary `LibKey` test case disabling

### DIFF
--- a/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
@@ -38,6 +38,6 @@ const testCases = [
 ];
 
 export {
-    testCases
+    testCases,
 };
 

--- a/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_AD-AD.js
@@ -30,7 +30,12 @@ const testCases = [
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
     },
     // Temporarily disabling this failing "Download via Unpaywall" test case.
-    // We will be getting a replacement docid from KARMS DAI soon.
+    // KARMS DAI is investigating its disappearance.  It's possible that the
+    // docid is a casualty of a recent CDI "disruption" that resulted in mass
+    // data loss.  Ex Libris is still in the process of restoring all the data.
+    // For details, see Primo email list thread:
+    // "Update: CDI details"
+    // https://exlibrisusers.org/hyperkitty/list/primo@exlibrisusers.org/thread/5MU2TN37MQXBV3EE3GQLDJH5K7OTG5VR/
     // {
     //     name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
     //     pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',

--- a/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
@@ -38,6 +38,6 @@ const testCases = [
 ];
 
 export {
-    testCases
+    testCases,
 };
 

--- a/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_INST-NYU.js
@@ -30,7 +30,12 @@ const testCases = [
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',
     },
     // Temporarily disabling this failing "Download via Unpaywall" test case.
-    // We will be getting a replacement docid from KARMS DAI soon.
+    // KARMS DAI is investigating its disappearance.  It's possible that the
+    // docid is a casualty of a recent CDI "disruption" that resulted in mass
+    // data loss.  Ex Libris is still in the process of restoring all the data.
+    // For details, see Primo email list thread:
+    // "Update: CDI details"
+    // https://exlibrisusers.org/hyperkitty/list/primo@exlibrisusers.org/thread/5MU2TN37MQXBV3EE3GQLDJH5K7OTG5VR/
     // {
     //     name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
     //     pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',

--- a/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
@@ -38,6 +38,6 @@ const testCases = [
 ];
 
 export {
-    testCases
+    testCases,
 };
 

--- a/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
+++ b/test/e2e/tests/view-config/libkey/01NYU_US-SH.js
@@ -30,7 +30,12 @@ const testCases = [
         pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_proquest_journals_2358492548&tab=default_slot&search_scope=CI_NYUSH_NYU&offset=0',
     },
     // Temporarily disabling this failing "Download via Unpaywall" test case.
-    // We will be getting a replacement docid from KARMS DAI soon.
+    // KARMS DAI is investigating its disappearance.  It's possible that the
+    // docid is a casualty of a recent CDI "disruption" that resulted in mass
+    // data loss.  Ex Libris is still in the process of restoring all the data.
+    // For details, see Primo email list thread:
+    // "Update: CDI details"
+    // https://exlibrisusers.org/hyperkitty/list/primo@exlibrisusers.org/thread/5MU2TN37MQXBV3EE3GQLDJH5K7OTG5VR/
     // {
     //     name         : 'docid: cdi_cleo_primary_oai_revues_org_chinaperspectives_7327',
     //     pathAndQuery : '/discovery/search?vid=[VID]&query=any,contains,cdi_cleo_primary_oai_revues_org_chinaperspectives_7327&tab=Unified_Slot&search_scope=DN_and_CI&offset=0',

--- a/test/unit/01-config-helpers.test.js
+++ b/test/unit/01-config-helpers.test.js
@@ -34,14 +34,14 @@ const testCases = {
     'https://hslcat.med.nyu.edu/discovery/search?vid=01NYU_HS:HSL&offset=0'     : 'https://cdn.library.nyu.edu/primo-customization/01NYU_HS-HSL',
     'https://hslcat.med.nyu.edu/discovery/search?vid=01NYU_HS:HSL_DEV&offset=0' : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_HS-HSL_DEV',
 
-    'https://localhost:3000/discovery/search?vid=01NYU_INST:NYU&offset=0'      : 'http://localhost:3000/primo-customization/01NYU_INST-NYU',
-    'https://localhost:3000/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0'  : 'http://localhost:3000/primo-customization/01NYU_INST-NYU_DEV',
+    'https://localhost:3000/discovery/search?vid=01NYU_INST:NYU&offset=0'     : 'http://localhost:3000/primo-customization/01NYU_INST-NYU',
+    'https://localhost:3000/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0' : 'http://localhost:3000/primo-customization/01NYU_INST-NYU_DEV',
 
-    'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU&offset=0'      : 'https://cdn.library.nyu.edu/primo-customization/01NYU_INST-NYU',
-    'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0'  : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_INST-NYU_DEV',
+    'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU&offset=0'     : 'https://cdn.library.nyu.edu/primo-customization/01NYU_INST-NYU',
+    'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0' : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_INST-NYU_DEV',
 
-    'https://sandbox02-na.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU&offset=0'      : 'https://d290kawcj1dea9.cloudfront.net/primo-customization/01NYU_INST-NYU',
-    'https://sandbox02-na.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0'  : 'https://d290kawcj1dea9.cloudfront.net/primo-customization/01NYU_INST-NYU_DEV',
+    'https://sandbox02-na.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU&offset=0'     : 'https://d290kawcj1dea9.cloudfront.net/primo-customization/01NYU_INST-NYU',
+    'https://sandbox02-na.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0' : 'https://d290kawcj1dea9.cloudfront.net/primo-customization/01NYU_INST-NYU_DEV',
 
     'https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD&offset=0'     : 'https://cdn.library.nyu.edu/primo-customization/01NYU_AD-AD',
     'https://search.abudhabi.library.nyu.edu/discovery/search?vid=01NYU_AD:AD_DEV&offset=0' : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_AD-AD_DEV',
@@ -58,8 +58,8 @@ const testCases = {
     'https://search.library.nysid.edu/discovery/search?vid=01NYU_NYSID:NYSID&offset=0'     : 'https://cdn.library.nyu.edu/primo-customization/01NYU_NYSID-NYSID',
     'https://search.library.nysid.edu/discovery/search?vid=01NYU_NYSID:NYSID_DEV&offset=0' : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_NYSID-NYSID_DEV',
 
-    'https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&offset=0'      : 'https://cdn.library.nyu.edu/primo-customization/01NYU_INST-NYU',
-    'https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0'  : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_INST-NYU_DEV',
+    'https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU&offset=0'     : 'https://cdn.library.nyu.edu/primo-customization/01NYU_INST-NYU',
+    'https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU_DEV&offset=0' : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_INST-NYU_DEV',
 
     'https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:US&offset=0'     : 'https://cdn.library.nyu.edu/primo-customization/01NYU_US-US',
     'https://search.shanghai.library.nyu.edu/discovery/search?vid=01NYU_US:US_DEV&offset=0' : 'https://cdn-dev.library.nyu.edu/primo-customization/01NYU_US-US_DEV',


### PR DESCRIPTION
* Updates the comment explaining why we are temporarily disabling a failing LibKey test case to include information about recent Ex Libris CDI data loss event: [Update: CDI details](https://exlibrisusers.org/hyperkitty/list/primo@exlibrisusers.org/thread/5MU2TN37MQXBV3EE3GQLDJH5K7OTG5VR/#SMJJYAKTEY3OXVPSCRZGA5QLEQODMXMJ)
* `yarn eslint:fix`
    * Restores [Trailing commas](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas) that might have been accidentally IDE-auto-deleted in earlier PR.  (eslint rule: [comma\-dangle](https://eslint.org/docs/latest/rules/comma-dangle))
    * Fixes whitespace errors in _01-config-helpers.test.js_ I'd made in initial commit.